### PR TITLE
Fix author key casing on Semina Verbi post

### DIFF
--- a/_posts/2020-10-12-encyclopedia-influence-gospel-human-culture.md
+++ b/_posts/2020-10-12-encyclopedia-influence-gospel-human-culture.md
@@ -3,7 +3,7 @@ layout: post
 title:  "Semina Verbi: an online encylopedia of the influence of the Gospel on human culture"
 date:   2020-10-12 15:56:00 +0200
 categories: [bible, evangelization, culture]
-author: JohnRDOrazio
+author: johnrdorazio
 comments: true
 ---
 


### PR DESCRIPTION
## Summary
- The `author` field on the 2020-10-12 Semina Verbi post was `JohnRDOrazio`, but the authors map in `_config.yml` keys it as lowercase `johnrdorazio`
- Because Jekyll couldn't resolve the key, the rendered post was missing its author info
- Changed the value to lowercase to match the authors map

## Test plan
- [ ] Build the site locally and confirm the Semina Verbi post renders author info the same way as the 2020-10-07 "Bringing the Word of God to the desktop" post

🤖 Generated with [Claude Code](https://claude.com/claude-code)